### PR TITLE
feat(cli): add query result count

### DIFF
--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -88,6 +88,18 @@ pub fn run(args: QueryArgs) -> Result<()> {
         OutputFormat::Table => print_table(&results),
     }
 
+    let count = results.len();
+    let prefix = match args.format {
+        OutputFormat::Json => "",
+        _ => "\n",
+    };
+    crate::status!(
+        "{}Found {} {}",
+        prefix,
+        count,
+        if count == 1 { "result" } else { "results" }
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
Display result count summary on stderr after query output, improving UX by confirming how many matches were found without breaking pipe compatibility.

Closes #5

## Changes
- Print "Found N result(s)" to stderr after query results
- Proper pluralization (1 result / N results)
- Blank line before summary for plain/table formats, none for JSON
- Respects `--quiet` flag (uses existing `status!` macro)

## Testing
- 6 new integration tests covering all acceptance criteria
- All 40 tests pass

---
Co-Authored-By: Aei <aei@oad.earth>