### PR TITLE
feat(cli): add hash command

### DIFF
--- a/src/cli/hash.rs
+++ b/src/cli/hash.rs
@@ -1,6 +1,6 @@
 use std::io::{self, BufRead, IsTerminal};
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use clap::{Args, ValueEnum};
 
 use crate::hasher;
@@ -29,8 +29,11 @@ pub fn run(args: HashArgs) -> Result<()> {
     let hashers: Vec<Box<dyn hasher::Hasher>> = args
         .algo
         .iter()
-        .map(|name| hasher::get_hasher(name).expect("algorithm validated by clap"))
-        .collect();
+        .map(|name| {
+            hasher::get_hasher(name)
+                .ok_or_else(|| anyhow!("Unsupported algorithm: {name}"))
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     let inputs = collect_inputs(&args)?;
 
@@ -58,7 +61,8 @@ fn collect_inputs(args: &HashArgs) -> Result<Vec<String>> {
     let reader = io::stdin().lock();
     let lines: Vec<String> = reader
         .lines()
-        .map_while(Result::ok)
+        .collect::<std::result::Result<Vec<_>, _>>()?
+        .into_iter()
         .filter(|line| !line.is_empty())
         .collect();
 

--- a/src/cli/hash.rs
+++ b/src/cli/hash.rs
@@ -1,0 +1,110 @@
+use std::io::{self, BufRead, IsTerminal};
+
+use anyhow::{bail, Result};
+use clap::{Args, ValueEnum};
+
+use crate::hasher;
+
+#[derive(Args)]
+pub struct HashArgs {
+    /// Text to hash (reads from stdin if omitted)
+    pub input: Option<String>,
+
+    /// Hash algorithms to use
+    #[arg(short, long, default_value = "sha256", value_parser = hasher::algo_value_parser())]
+    pub algo: Vec<String>,
+
+    /// Output format
+    #[arg(short, long, default_value = "plain")]
+    pub format: OutputFormat,
+}
+
+#[derive(Clone, ValueEnum)]
+pub enum OutputFormat {
+    Plain,
+    Json,
+}
+
+pub fn run(args: HashArgs) -> Result<()> {
+    let hashers: Vec<Box<dyn hasher::Hasher>> = args
+        .algo
+        .iter()
+        .map(|name| hasher::get_hasher(name).expect("algorithm validated by clap"))
+        .collect();
+
+    let inputs = collect_inputs(&args)?;
+
+    if inputs.is_empty() {
+        bail!("No input provided. Pass text as argument or pipe via stdin.");
+    }
+
+    match args.format {
+        OutputFormat::Plain => print_plain(&inputs, &hashers),
+        OutputFormat::Json => print_json(&inputs, &hashers)?,
+    }
+
+    Ok(())
+}
+
+fn collect_inputs(args: &HashArgs) -> Result<Vec<String>> {
+    if let Some(ref text) = args.input {
+        return Ok(vec![text.clone()]);
+    }
+
+    if io::stdin().is_terminal() {
+        return Ok(vec![]);
+    }
+
+    let reader = io::stdin().lock();
+    let lines: Vec<String> = reader
+        .lines()
+        .map_while(Result::ok)
+        .filter(|line| !line.is_empty())
+        .collect();
+
+    Ok(lines)
+}
+
+fn print_plain(inputs: &[String], hashers: &[Box<dyn hasher::Hasher>]) {
+    let single_algo = hashers.len() == 1;
+    let single_input = inputs.len() == 1;
+
+    for input in inputs {
+        for hasher in hashers {
+            let hash = hex::encode(hasher.hash(input.as_bytes()));
+
+            if single_input && single_algo {
+                println!("{hash}");
+            } else if single_algo {
+                println!("{hash}  {input}");
+            } else if single_input {
+                println!("{hash}  {}", hasher.name());
+            } else {
+                println!("{hash}  {}  {input}", hasher.name());
+            }
+        }
+    }
+}
+
+fn print_json(inputs: &[String], hashers: &[Box<dyn hasher::Hasher>]) -> Result<()> {
+    #[derive(serde::Serialize)]
+    struct JsonHash {
+        input: String,
+        algorithm: String,
+        hash: String,
+    }
+
+    let results: Vec<JsonHash> = inputs
+        .iter()
+        .flat_map(|input| {
+            hashers.iter().map(move |hasher| JsonHash {
+                input: input.clone(),
+                algorithm: hasher.name().to_string(),
+                hash: hex::encode(hasher.hash(input.as_bytes())),
+            })
+        })
+        .collect();
+
+    println!("{}", serde_json::to_string_pretty(&results)?);
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod build;
+pub mod hash;
 pub mod info;
 pub mod query;
 pub mod source;
@@ -22,6 +23,8 @@ pub struct Cli {
 pub enum Commands {
     /// Build hash database from input file
     Build(build::BuildArgs),
+    /// Compute hash of input text
+    Hash(hash::HashArgs),
     /// Query hash database for preimage
     Query(query::QueryArgs),
     /// Show database statistics

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ fn main() -> Result<()> {
 
     match cli.command {
         Commands::Build(args) => shaha::cli::build::run(args),
+        Commands::Hash(args) => shaha::cli::hash::run(args),
         Commands::Query(args) => shaha::cli::query::run(args),
         Commands::Info(args) => shaha::cli::info::run(args),
         Commands::Source(args) => shaha::cli::source::run(args),


### PR DESCRIPTION
## Summary
Adds `shaha hash` subcommand for computing hashes directly without building a database. Natural gap in the CLI for a tool named "SHA + aha!".

Closes #12

## Changes
- New `src/cli/hash.rs` — command handler with stdin pipe support, multi-algorithm, plain/json output
- Register `Hash` variant in `Commands` enum and main dispatch

## Usage
```bash
shaha hash "hello"                         # sha256 by default
shaha hash "hello" -a md5 -a keccak256     # multiple algorithms
echo -e "foo\nbar" | shaha hash            # stdin pipe
shaha hash "test" --format json            # JSON output
```

## Testing
- `cargo build` — clean
- `cargo test` — 47/47 pass
- Manual verification of all output modes (single/multi input × single/multi algo × plain/json)
- LSP diagnostics clean on all changed files

---
Co-Authored-By: Ori <18102267+oritwoen@users.noreply.github.com>