### PR TITLE
refactor(cli): extract shared R2Args

### DIFF
--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -6,12 +6,11 @@ use clap::Args;
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
 
-use crate::config::{Config, R2Overrides};
 use crate::hasher::{self, Hasher};
 use crate::output;
 use crate::source;
 use crate::status;
-use crate::storage::{HashRecord, ParquetStorage, R2Config, R2Storage, Storage};
+use crate::storage::{HashRecord, ParquetStorage, R2Storage, Storage};
 
 const BATCH_SIZE: usize = 100_000;
 
@@ -47,33 +46,8 @@ pub struct BuildArgs {
     #[arg(long)]
     pub dry_run: bool,
 
-    /// Upload to R2/S3 storage instead of local file
-    #[arg(long)]
-    pub r2: bool,
-
-    /// R2/S3 endpoint URL (or SHAHA_R2_ENDPOINT env var)
-    #[arg(long, env = "SHAHA_R2_ENDPOINT")]
-    pub endpoint: Option<String>,
-
-    /// R2/S3 bucket name (or SHAHA_R2_BUCKET env var)
-    #[arg(long, env = "SHAHA_R2_BUCKET")]
-    pub bucket: Option<String>,
-
-    /// R2/S3 access key ID (or SHAHA_R2_ACCESS_KEY_ID or AWS_ACCESS_KEY_ID env var)
-    #[arg(long, env = "SHAHA_R2_ACCESS_KEY_ID")]
-    pub access_key_id: Option<String>,
-
-    /// R2/S3 secret access key (or SHAHA_R2_SECRET_ACCESS_KEY or AWS_SECRET_ACCESS_KEY env var)
-    #[arg(long, env = "SHAHA_R2_SECRET_ACCESS_KEY")]
-    pub secret_access_key: Option<String>,
-
-    /// Path within bucket (defaults to output filename)
-    #[arg(long, env = "SHAHA_R2_PATH")]
-    pub r2_path: Option<String>,
-
-    /// R2/S3 region (default: "auto" for R2)
-    #[arg(long, env = "SHAHA_R2_REGION", default_value = "auto")]
-    pub region: String,
+    #[command(flatten)]
+    pub r2: super::R2Args,
 }
 
 type RecordKey = (Vec<u8>, String);
@@ -110,7 +84,7 @@ pub fn run(args: BuildArgs) -> Result<()> {
         return run_dry_run(&args, data_source.as_ref(), &hashers, source_hash);
     }
 
-    if !args.force && !args.r2 && args.output.exists() {
+    if !args.force && !args.r2.enabled && args.output.exists() {
         if let Some(ref hash) = source_hash {
             let existing_storage = ParquetStorage::new(&args.output);
             let existing_hashes = existing_storage.get_source_hashes()?;
@@ -177,7 +151,7 @@ pub fn run(args: BuildArgs) -> Result<()> {
     let mut merged_count = 0usize;
     let mut final_records: Vec<HashRecord> = Vec::new();
 
-    if args.append && !args.r2 && args.output.exists() {
+    if args.append && !args.r2.enabled && args.output.exists() {
         status!("Streaming existing database for merge...");
         let existing_storage = ParquetStorage::new(&args.output);
         
@@ -209,8 +183,8 @@ pub fn run(args: BuildArgs) -> Result<()> {
 
     let output_location: String;
     
-    if args.r2 {
-        let r2_config = build_r2_config(&args)?;
+    if args.r2.enabled {
+        let r2_config = args.r2.build_config(&args.output)?;
         output_location = r2_config.s3_url();
         
         status!("Uploading to {}...", output_location);
@@ -263,7 +237,7 @@ fn run_dry_run(
 
     let mut already_processed = false;
 
-    if !args.r2 && args.output.exists() {
+    if !args.r2.enabled && args.output.exists() {
         if let Some(ref hash) = source_hash {
             let existing_storage = ParquetStorage::new(&args.output);
             let existing_hashes = existing_storage.get_source_hashes()?;
@@ -277,7 +251,7 @@ fn run_dry_run(
         }
     }
 
-    if args.append && !args.r2 && args.output.exists() {
+    if args.append && !args.r2.enabled && args.output.exists() {
         let existing_storage = ParquetStorage::new(&args.output);
         let stats = existing_storage.stats()?;
         eprintln!(
@@ -305,8 +279,8 @@ fn run_dry_run(
         format_number(record_count)
     );
 
-    let output_location = if args.r2 {
-        let r2_config = build_r2_config(args)?;
+    let output_location = if args.r2.enabled {
+        let r2_config = args.r2.build_config(&args.output)?;
         r2_config.s3_url()
     } else {
         args.output.display().to_string()
@@ -326,23 +300,6 @@ fn run_dry_run(
     Ok(())
 }
 
-fn build_r2_config(args: &BuildArgs) -> Result<R2Config> {
-    let default_path = args.output.file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| "hashes.parquet".to_string());
-
-    let overrides = R2Overrides {
-        endpoint: args.endpoint.as_deref(),
-        bucket: args.bucket.as_deref(),
-        access_key_id: args.access_key_id.as_deref(),
-        secret_access_key: args.secret_access_key.as_deref(),
-        path: args.r2_path.as_deref(),
-        region: &args.region,
-        default_path: &default_path,
-    };
-
-    Config::load().unwrap_or_default().build_r2_config(overrides)
-}
 
 fn process_new_words(
     words: &[String],

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -3,8 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::{Args, ValueEnum};
 
-use crate::config::{Config, R2Overrides};
-use crate::storage::{ParquetStorage, R2Config, R2Storage, Storage};
+use crate::storage::{ParquetStorage, R2Storage, Storage};
 
 #[derive(Clone, ValueEnum)]
 pub enum OutputFormat {
@@ -19,32 +18,13 @@ pub struct InfoArgs {
 
     #[arg(short, long, default_value = "plain")]
     pub format: OutputFormat,
-
-    #[arg(long)]
-    pub r2: bool,
-
-    #[arg(long, env = "SHAHA_R2_ENDPOINT")]
-    pub endpoint: Option<String>,
-
-    #[arg(long, env = "SHAHA_R2_BUCKET")]
-    pub bucket: Option<String>,
-
-    #[arg(long, env = "SHAHA_R2_ACCESS_KEY_ID")]
-    pub access_key_id: Option<String>,
-
-    #[arg(long, env = "SHAHA_R2_SECRET_ACCESS_KEY")]
-    pub secret_access_key: Option<String>,
-
-    #[arg(long, env = "SHAHA_R2_PATH")]
-    pub r2_path: Option<String>,
-
-    #[arg(long, env = "SHAHA_R2_REGION", default_value = "auto")]
-    pub region: String,
+    #[command(flatten)]
+    pub r2: super::R2Args,
 }
 
 pub fn run(args: InfoArgs) -> Result<()> {
-    let (stats, location) = if args.r2 {
-        let r2_config = build_r2_config(&args)?;
+    let (stats, location) = if args.r2.enabled {
+        let r2_config = args.r2.build_config(&args.database)?;
         let url = r2_config.s3_url();
         let storage = R2Storage::new(r2_config)?;
         (storage.stats()?, url)
@@ -112,23 +92,6 @@ fn print_json(location: &str, stats: &crate::storage::Stats) -> Result<()> {
     Ok(())
 }
 
-fn build_r2_config(args: &InfoArgs) -> Result<R2Config> {
-    let default_path = args.database.file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| "hashes.parquet".to_string());
-
-    let overrides = R2Overrides {
-        endpoint: args.endpoint.as_deref(),
-        bucket: args.bucket.as_deref(),
-        access_key_id: args.access_key_id.as_deref(),
-        secret_access_key: args.secret_access_key.as_deref(),
-        path: args.r2_path.as_deref(),
-        region: &args.region,
-        default_path: &default_path,
-    };
-
-    Config::load().unwrap_or_default().build_r2_config(overrides)
-}
 
 fn format_bytes(bytes: u64) -> String {
     const KB: u64 = 1024;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -87,6 +87,6 @@ impl R2Args {
             default_path: &default_path,
         };
 
-        Config::load().unwrap_or_default().build_r2_config(overrides)
+        Config::load()?.build_r2_config(overrides)
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,7 +4,7 @@ pub mod info;
 pub mod query;
 pub mod source;
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(name = "shaha")]
@@ -31,4 +31,62 @@ pub enum Commands {
     Info(info::InfoArgs),
     /// Manage source providers (seclists, aspell)
     Source(source::SourceArgs),
+}
+
+use std::path::Path;
+
+use anyhow::Result;
+use crate::config::{Config, R2Overrides};
+use crate::storage::R2Config;
+
+#[derive(Args)]
+pub struct R2Args {
+    /// Upload to R2/S3 storage instead of local file
+    #[arg(long = "r2")]
+    pub enabled: bool,
+
+    /// R2/S3 endpoint URL (or SHAHA_R2_ENDPOINT env var)
+    #[arg(long, env = "SHAHA_R2_ENDPOINT")]
+    pub endpoint: Option<String>,
+
+    /// R2/S3 bucket name (or SHAHA_R2_BUCKET env var)
+    #[arg(long, env = "SHAHA_R2_BUCKET")]
+    pub bucket: Option<String>,
+
+    /// R2/S3 access key ID (or SHAHA_R2_ACCESS_KEY_ID or AWS_ACCESS_KEY_ID env var)
+    #[arg(long, env = "SHAHA_R2_ACCESS_KEY_ID")]
+    pub access_key_id: Option<String>,
+
+    /// R2/S3 secret access key (or SHAHA_R2_SECRET_ACCESS_KEY or AWS_SECRET_ACCESS_KEY env var)
+    #[arg(long, env = "SHAHA_R2_SECRET_ACCESS_KEY")]
+    pub secret_access_key: Option<String>,
+
+    /// Path within bucket (defaults to output filename)
+    #[arg(long, env = "SHAHA_R2_PATH")]
+    pub r2_path: Option<String>,
+
+    /// R2/S3 region (default: "auto" for R2)
+    #[arg(long, env = "SHAHA_R2_REGION", default_value = "auto")]
+    pub region: String,
+}
+
+impl R2Args {
+    pub fn build_config(&self, fallback_path: &Path) -> Result<R2Config> {
+        let default_path = fallback_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "hashes.parquet".to_string());
+
+        let overrides = R2Overrides {
+            endpoint: self.endpoint.as_deref(),
+            bucket: self.bucket.as_deref(),
+            access_key_id: self.access_key_id.as_deref(),
+            secret_access_key: self.secret_access_key.as_deref(),
+            path: self.r2_path.as_deref(),
+            region: &self.region,
+            default_path: &default_path,
+        };
+
+        Config::load().unwrap_or_default().build_r2_config(overrides)
+    }
 }

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -4,9 +4,8 @@ use anyhow::{bail, Result};
 use clap::{Args, ValueEnum};
 use comfy_table::{presets::UTF8_FULL, Table};
 
-use crate::config::{Config, R2Overrides};
 use crate::hasher;
-use crate::storage::{HashRecord, ParquetStorage, R2Config, R2Storage, Storage};
+use crate::storage::{HashRecord, ParquetStorage, R2Storage, Storage};
 
 #[derive(Args)]
 pub struct QueryArgs {
@@ -25,33 +24,8 @@ pub struct QueryArgs {
     #[arg(short, long, default_value = "plain")]
     pub format: OutputFormat,
 
-    /// Query from R2/S3 storage instead of local file
-    #[arg(long)]
-    pub r2: bool,
-
-    /// R2/S3 endpoint URL (or SHAHA_R2_ENDPOINT env var)
-    #[arg(long, env = "SHAHA_R2_ENDPOINT")]
-    pub endpoint: Option<String>,
-
-    /// R2/S3 bucket name (or SHAHA_R2_BUCKET env var)
-    #[arg(long, env = "SHAHA_R2_BUCKET")]
-    pub bucket: Option<String>,
-
-    /// R2/S3 access key ID (or SHAHA_R2_ACCESS_KEY_ID or AWS_ACCESS_KEY_ID env var)
-    #[arg(long, env = "SHAHA_R2_ACCESS_KEY_ID")]
-    pub access_key_id: Option<String>,
-
-    /// R2/S3 secret access key (or SHAHA_R2_SECRET_ACCESS_KEY or AWS_SECRET_ACCESS_KEY env var)
-    #[arg(long, env = "SHAHA_R2_SECRET_ACCESS_KEY")]
-    pub secret_access_key: Option<String>,
-
-    /// Path within bucket (defaults to database filename)
-    #[arg(long, env = "SHAHA_R2_PATH")]
-    pub r2_path: Option<String>,
-
-    /// R2/S3 region (default: "auto" for R2)
-    #[arg(long, env = "SHAHA_R2_REGION", default_value = "auto")]
-    pub region: String,
+    #[command(flatten)]
+    pub r2: super::R2Args,
 
     /// Maximum number of results to return
     #[arg(short, long)]
@@ -69,8 +43,8 @@ pub fn run(args: QueryArgs) -> Result<()> {
     let hash_bytes = hex::decode(&args.hash)
         .map_err(|_| anyhow::anyhow!("Invalid hex string: {}", args.hash))?;
 
-    let results = if args.r2 {
-        let r2_config = build_r2_config(&args)?;
+    let results = if args.r2.enabled {
+        let r2_config = args.r2.build_config(&args.database)?;
         let storage = R2Storage::new(r2_config)?;
         storage.query(&hash_bytes, args.algo.as_deref(), args.limit)?
     } else {
@@ -103,23 +77,6 @@ pub fn run(args: QueryArgs) -> Result<()> {
     Ok(())
 }
 
-fn build_r2_config(args: &QueryArgs) -> Result<R2Config> {
-    let default_path = args.database.file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| "hashes.parquet".to_string());
-
-    let overrides = R2Overrides {
-        endpoint: args.endpoint.as_deref(),
-        bucket: args.bucket.as_deref(),
-        access_key_id: args.access_key_id.as_deref(),
-        secret_access_key: args.secret_access_key.as_deref(),
-        path: args.r2_path.as_deref(),
-        region: &args.region,
-        default_path: &default_path,
-    };
-
-    Config::load().unwrap_or_default().build_r2_config(overrides)
-}
 
 fn format_sources(sources: &[String]) -> String {
     if sources.is_empty() {


### PR DESCRIPTION
## Summary
Extract duplicated R2/S3 CLI args and config builder into a shared `R2Args` struct using clap `#[command(flatten)]`.

Closes #14

## Changes
- Add `R2Args` struct with `build_config()` method in `cli/mod.rs`
- Replace 7 identical R2 fields in `BuildArgs`, `QueryArgs`, `InfoArgs` with `#[command(flatten)]`
- Remove 3 duplicate `build_r2_config` functions
- Net: +80 / -145 lines

## Testing
`cargo test` — 40/40 pass, zero diagnostics on changed files.

---
Co-Authored-By: Aei <256851514+aeitwoen@users.noreply.github.com>