### PR TITLE
fix(source): reject HTTP error responses in UrlSource

### DIFF
--- a/src/source/url.rs
+++ b/src/source/url.rs
@@ -22,6 +22,12 @@ impl UrlSource {
 
         let response = reqwest::blocking::get(&url)
             .with_context(|| format!("Failed to fetch URL: {}", url))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            anyhow::bail!("HTTP {} from {}", status, url);
+        }
+
         let content = response
             .text()
             .with_context(|| format!("Failed to read response from: {}", url))?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -519,7 +519,7 @@ fn test_url_source_fetch_error_connection_refused() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_url_source_http_500_succeeds() {
+async fn test_url_source_http_500_fails() {
     use wiremock::matchers::method;
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -531,11 +531,35 @@ async fn test_url_source_http_500_succeeds() {
         .await;
 
     let uri = mock_server.uri();
-    let source = tokio::task::spawn_blocking(move || UrlSource::new(&uri))
+    let result = tokio::task::spawn_blocking(move || UrlSource::new(&uri))
         .await
         .unwrap();
 
-    assert!(source.is_ok());
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert!(err.to_string().contains("HTTP 500"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_url_source_http_404_fails() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&mock_server)
+        .await;
+
+    let uri = mock_server.uri();
+    let result = tokio::task::spawn_blocking(move || UrlSource::new(&uri))
+        .await
+        .unwrap();
+
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert!(err.to_string().contains("HTTP 404"));
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
`UrlSource::new()` was calling `reqwest::blocking::get()` without checking the status code. A 404 or 500 response got silently treated as valid content, so you'd end up hashing an HTML error page instead of getting an error.

Added a status check before reading the body. Updated the existing `test_url_source_http_500_succeeds` (which was testing the broken behavior) and added a 404 test.

Closes #16