### PR TITLE
fix(source): propagate I/O errors instead of silently stopping

### DIFF
--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -32,12 +32,14 @@ impl Source for FileSource {
         let file = File::open(&self.path)
             .with_context(|| format!("Failed to open file: {:?}", self.path))?;
         let reader = BufReader::new(file);
-        Ok(Box::new(
-            reader
-                .lines()
-                .map_while(Result::ok)
-                .filter(|line| !line.is_empty()),
-        ))
+        let lines: Vec<String> = reader
+            .lines()
+            .collect::<std::io::Result<Vec<_>>>()
+            .with_context(|| format!("I/O error reading file: {:?}", self.path))?
+            .into_iter()
+            .filter(|line| !line.is_empty())
+            .collect();
+        Ok(Box::new(lines.into_iter()))
     }
 
     fn content_hash(&self) -> Result<Option<String>> {

--- a/src/source/seclists.rs
+++ b/src/source/seclists.rs
@@ -48,12 +48,14 @@ impl Source for SecListsSource {
         let file = File::open(&self.full_path)
             .with_context(|| format!("Failed to open: {:?}", self.full_path))?;
         let reader = BufReader::new(file);
-        Ok(Box::new(
-            reader
-                .lines()
-                .map_while(Result::ok)
-                .filter(|line| !line.is_empty()),
-        ))
+        let lines: Vec<String> = reader
+            .lines()
+            .collect::<std::io::Result<Vec<_>>>()
+            .with_context(|| format!("I/O error reading: {:?}", self.full_path))?
+            .into_iter()
+            .filter(|line| !line.is_empty())
+            .collect();
+        Ok(Box::new(lines.into_iter()))
     }
 
     fn content_hash(&self) -> Result<Option<String>> {

--- a/src/source/stdin.rs
+++ b/src/source/stdin.rs
@@ -25,12 +25,13 @@ impl Source for StdinSource {
 
     fn words(&self) -> Result<Box<dyn Iterator<Item = String>>> {
         let reader = BufReader::new(io::stdin());
-        Ok(Box::new(
-            reader
-                .lines()
-                .map_while(Result::ok)
-                .filter(|line| !line.is_empty()),
-        ))
+        let lines: Vec<String> = reader
+            .lines()
+            .collect::<io::Result<Vec<_>>>()?
+            .into_iter()
+            .filter(|line| !line.is_empty())
+            .collect();
+        Ok(Box::new(lines.into_iter()))
     }
 
     fn content_hash(&self) -> Result<Option<String>> {


### PR DESCRIPTION
All file-based sources (FileSource, SecListsSource, StdinSource) used `.map_while(Result::ok)` on line iterators. If a read failed mid-file, the iterator just stopped and the build continued with partial data - no error, no warning.

Switched to eager `.collect::<io::Result<Vec<_>>>()` which surfaces the first I/O error through the `?` chain. The words are buffered in memory anyway (the build loop puts everything into a `HashSet`), so there's no streaming penalty.

Closes #22