### PR TITLE
fix(cli): show matched hash in query plain and table output

### DIFF
--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -89,8 +89,11 @@ fn format_sources(sources: &[String]) -> String {
 fn print_plain(results: &[HashRecord]) {
     for r in results {
         println!(
-            "{} ({}, {})",
-            r.preimage, r.algorithm, format_sources(&r.sources)
+            "{}  {}  {} ({})",
+            hex::encode(&r.hash),
+            r.preimage,
+            r.algorithm,
+            format_sources(&r.sources)
         );
     }
 }
@@ -122,10 +125,11 @@ fn print_json(results: &[HashRecord]) -> Result<()> {
 fn print_table(results: &[HashRecord]) {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL);
-    table.set_header(vec!["Preimage", "Algorithm", "Sources"]);
+    table.set_header(vec!["Hash", "Preimage", "Algorithm", "Sources"]);
 
     for r in results {
         table.add_row(vec![
+            hex::encode(&r.hash),
             r.preimage.clone(),
             r.algorithm.clone(),
             format_sources(&r.sources),


### PR DESCRIPTION
Plain format was printing just the preimage, algorithm and sources - but not the actual hash that matched. When querying by prefix, there's no way to tell which full hash corresponds to which result.

Before: `password (sha256, rockyou)`
After: `5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8  password  sha256 (rockyou)`

Also added the hash column to table format for consistency. JSON format already included it.

Closes #18