### PR TITLE
fix(cli): exit successfully on zero query results

### DIFF
--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use clap::{Args, ValueEnum};
 use comfy_table::{presets::UTF8_FULL, Table};
 
@@ -53,7 +53,8 @@ pub fn run(args: QueryArgs) -> Result<()> {
     };
 
     if results.is_empty() {
-        bail!("No matches found");
+        crate::status!("No matches found");
+        return Ok(());
     }
 
     match args.format {


### PR DESCRIPTION
`shaha query` was using `bail!()` when no results matched, which makes the process exit with code 1. Zero results is a valid query outcome, not an error - it breaks scripts that use exit codes to distinguish "query worked, nothing found" from "something actually went wrong" (bad hex input, missing database, I/O failure).

Replaced the bail with a stderr message and `Ok(())`.

Closes #19